### PR TITLE
Remove redundant dependencies

### DIFF
--- a/mr/pom.xml
+++ b/mr/pom.xml
@@ -18,6 +18,48 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <version>2.7.4</version>
+	    <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet.jsp</groupId>
+                    <artifactId>jsp-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-jaxrs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.directory.server</groupId>
+                    <artifactId>apacheds-i18n</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
@junneyang Hi, I am a user of project **_com.xcompany.xproject:mr:1.0.0-RELEASE_**. I found that its pom file introduced **_72_** dependencies. However, among them, **_12_** libraries (**_16%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_com.xcompany.xproject:mr:1.0.0-RELEASE_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
com.google.code.findbugs:jsr305:jar:3.0.0:compile
javax.servlet.jsp:jsp-api:jar:2.1:runtime
com.sun.jersey:jersey-core:jar:1.9:compile
org.codehaus.jackson:jackson-jaxrs:jar:1.9.13:compile
xml-apis:xml-apis:jar:1.3.04:compile
org.apache.hadoop:hadoop-annotations:jar:2.7.4:compile
com.sun.jersey:jersey-client:jar:1.9:compile
org.apache.directory.server:apacheds-i18n:jar:2.0.0-M15:compile
javax.xml.bind:jaxb-api:jar:2.2.2:compile
javax.activation:activation:jar:1.1:compile
javax.xml.stream:stax-api:jar:1.0-2:compile
javax.servlet:servlet-api:jar:2.5:compile
</code></pre>